### PR TITLE
Add browserify and frau-publisher scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 coverage/
+dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ node_js: stable
 sudo: false
 after_success:
 - npm run report-coverage
+- npm run browserify
+- '[ "$TRAVIS_SECURE_ENV_VARS" = "true" ] && [ "x$TRAVIS_TAG" != "x" ] && npm run publish:cdn'
 deploy:
   provider: npm
   email: d2ltravisdeploy@d2l.com
@@ -11,3 +13,6 @@ deploy:
   on:
     tags: true
     repo: Brightspace/frau-locale-provider
+env:
+  global:
+  - secure: "JrlBirmjbW3TjJlD2JzNrH6e4AM/LuvzCACe6g+dOCZ9fA0MiTI3ONlUpY1RbuxWR9LZO+4JCSOEmej1M7rqW1gjiUKzB+slR8UQmDIg3/wP8ZUdOQqAxbz/vKb5AMCJB3zsfcc0WdJ7hZueNk/Ah3Deq0SZ9mUxGXQ3a+hkR4I="

--- a/package.json
+++ b/package.json
@@ -4,10 +4,25 @@
   "description": "Free range app utility for providing information about the current user's locale within the ILP",
   "main": "src/index.js",
   "scripts": {
+    "prebrowserify": "rimraf dist && mkdir dist",
+    "browserify": "browserify -g uglifyify -s 'frauLocaleProvider' src/index.js > ./dist/frau-locale-provider.js",
     "lint": "eslint .",
     "test:unit": "istanbul cover _mocha test/*.js -- -R spec",
     "test": "npm run lint -s && npm run test:unit -s",
-    "report-coverage": "coveralls < ./coverage/lcov.info"
+    "report-coverage": "coveralls < ./coverage/lcov.info",
+    "publish:cdn": "frau-publisher"
+  },
+  "config": {
+    "frauPublisher": {
+      "files": "./dist/*.js",
+      "moduleType": "lib",
+      "targetDirectory": "frau-locale-provider",
+      "creds": {
+        "key": "AKIAIN2E2JXWLIOZUHJQ",
+        "secretVar": "CDN_SECRET"
+      },
+      "versionVar": "TRAVIS_TAG"
+    }
   },
   "repository": {
     "type": "git",
@@ -25,12 +40,16 @@
   },
   "homepage": "https://github.com/Brightspace/frau-locale-provider",
   "devDependencies": {
+    "browserify": "^14.4.0",
     "chai": "^3.5.0",
     "coveralls": "^2.13.1",
     "eslint": "^3.19.0",
     "eslint-config-brightspace": "^0.2.4",
+    "frau-publisher": "^2.6.2",
     "istanbul": "^0.4.5",
     "mocha": "^3.4.1",
-    "sinon": "^2.2.0"
+    "rimraf": "^2.6.1",
+    "sinon": "^2.2.0",
+    "uglifyify": "^4.0.2"
   }
 }


### PR DESCRIPTION
This PR adds a browserify build script and frau-publisher deploy script to get this library onto the Brightspace CDN.

I have the export name as "frauLocaleProvider" currently because I can't think of an appropriate namespace: `siren-parser` exposes `window.D2L.Thingy.Majig` style, but `ifrau` exposes `window.ifrauclient`.

cc: @dlockhart