### PR TITLE
feat: add cy-GB, es-ES, fr-FR languages to config.js

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -46,3 +46,4 @@ module.exports = {
 		'en-AU': 'en-GB'
 	}
 };
+


### PR DESCRIPTION
Add **cy-GB**, **es-ES**, **fr-FR** language to config.js
Our `DataHub` app has language packages for [cy-GB](https://github.com/Brightspace/datahub/blob/master/src/lang/cy-gb.json), [es-ES](https://github.com/Brightspace/datahub/blob/master/src/lang/es-es.json) and [fr-FR](https://github.com/Brightspace/datahub/blob/master/src/lang/fr-fr.json) that are not supported by `frau-locale-provider`.