### PR TITLE
add publishConfig.registry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
     "url": "https://github.com/Brightspace/frau-locale-provider/issues"
   },
   "homepage": "https://github.com/Brightspace/frau-locale-provider",
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
   "devDependencies": {
     "chai": "^6",
     "mocha": "^11",


### PR DESCRIPTION
Needed to publish to public NPM while reading packages from our proxy registry

HOD-4564