### PR TITLE
Import supported locales from @brightspace-ui/intl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,11 +8,40 @@
       "name": "frau-locale-provider",
       "version": "1.10.0",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@brightspace-ui/intl": "^3.40.1"
+      },
       "devDependencies": {
         "chai": "^6",
         "mocha": "^11",
         "sinon": "^22"
       }
+    },
+    "node_modules/@brightspace-ui/intl": {
+      "version": "3.40.1",
+      "integrity": "sha512-DNLlrexopVOPHLYArE1UaC/h1JPwCRgTFDZPzPsLgp+cjQqSkp4K/35YMlb8f6KkWKZy5nL4mc2n18YCWtMlWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "intl-messageformat": "^11"
+      }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.7",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.15",
+      "integrity": "sha512-5o4grXKotAB3JqQuisLApHG43g17N+paoRTa92Jiz35Zvfemq0cVf4EDvuxyHAzmsJji7igaEowicLO/VmfJ8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.11"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.11",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
     },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
@@ -458,6 +487,15 @@
       "license": "MIT",
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.12",
+      "integrity": "sha512-KW70Xxfcvy7vV3qODfvShWkFDPMqKDAa4N+hSyVBWGNtVhTUFYaqlD/l88DaYPKiVcPP4rPQ3qnH7i5K82Mg7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.15"
       }
     },
     "node_modules/is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -31,5 +31,8 @@
     "chai": "^6",
     "mocha": "^11",
     "sinon": "^22"
+  },
+  "dependencies": {
+    "@brightspace-ui/intl": "^3.40.1"
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -1,62 +1,12 @@
 'use strict';
 
+var supported = require('@brightspace-ui/intl/lib/locale-data/supported.js');
+
 module.exports = {
 	defaultLangTag: 'en',
-	primary: [
-		'ar',
-		'ca',
-		'da',
-		'de',
-		'en',
-		'es',
-		'fi',
-		'fr',
-		'haw',
-		'hi',
-		'ja',
-		'ko',
-		'mi',
-		'nb',
-		'nl',
-		'pt',
-		'sv',
-		'th',
-		'tr',
-		'vi',
-		'zh'
-	],
-	regions: [
-		'ar-SA',
-		'ca-ES',
-		'cy-GB',
-		'da-DK',
-		'de-DE',
-		'en-CA',
-		'en-GB',
-		'en-US',
-		'es-MX',
-		'es-ES',
-		'fi-FI',
-		'fr-CA',
-		'fr-FR',
-		'fr-ON',
-		'haw-US',
-		'hi-IN',
-		'ja-JP',
-		'ko-KR',
-		'mi-NZ',
-		'nb-NO',
-		'nl-NL',
-		'pt-BR',
-		'sv-SE',
-		'th-TH',
-		'tr-TR',
-		'vi-VN',
-		'zh-CN',
-		'zh-TW'
-	],
+	primary: supported.supportedBaseLocales,
+	regions: supported.supportedLocales,
 	aliases: {
 		'en-AU': 'en-GB'
 	}
 };
-

--- a/src/config.js
+++ b/src/config.js
@@ -1,11 +1,12 @@
 'use strict';
 
 var supported = require('@brightspace-ui/intl/lib/locale-data/supported.js');
+var normalizeLangTag = require('./normalizeLangTag');
 
 module.exports = {
 	defaultLangTag: 'en',
 	primary: supported.supportedBaseLocales,
-	regions: supported.supportedLocales,
+	regions: supported.supportedLocales.map(l => normalizeLangTag(l)),
 	aliases: {
 		'en-AU': 'en-GB'
 	}


### PR DESCRIPTION
[GAUD-10343](https://desire2learn.atlassian.net/browse/GAUD-10343): Update frau-locale-provider to import supported locales from intl library

Since node 22 `require` can import es6 modules, and all relevant repos are on node 24

[GAUD-10343]: https://desire2learn.atlassian.net/browse/GAUD-10343?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ